### PR TITLE
Fix Windows paths

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,6 +38,6 @@ def strip_invisible() -> typing.Callable[[str], str]:
 WindowsPyPathPattern = re.compile(r"[a-z_\\]+\.py")
 
 
-def fix_paths(line: str) -> str:
+def fix_paths(text: str) -> str:
     """On Windows the path separator is \\, not /. This makes all python paths in mypy output use / for consistency."""
-    return WindowsPyPathPattern.sub(lambda l: l.group().replace("\\", "/"), line)
+    return WindowsPyPathPattern.sub(lambda l: l.group().replace("\\", "/"), text)

--- a/tests/test_mypy_plugin.py
+++ b/tests/test_mypy_plugin.py
@@ -1,6 +1,5 @@
 import typing
 from pathlib import Path
-import re
 
 import pytest
 
@@ -13,14 +12,6 @@ class _TestCase(typing.NamedTuple):
     path: Path
     expected_stdout: str
     expected_stderr: str
-
-
-WindowsPathPattern = re.compile(r"[a-z_\\]+\.py")
-
-
-def fix_paths(line: str) -> str:
-    """On Windows the path separator is \\ not /. This finds all python paths in tests and fixes them."""
-    return WindowsPathPattern.sub(lambda l: l.group().replace("\\", "/"), line)
 
 
 def get_expected_stdout(contents: str) -> str:
@@ -105,7 +96,7 @@ def testcase_file(request, strip_invisible):
 )
 def test_mypy_plugin(testcase_file: _TestCase, run_mypy):
     stdout, stderr = run_mypy(testcase_file.path)
-    assert (fix_paths(stdout.strip()), fix_paths(stderr.strip())) == (testcase_file.expected_stdout, testcase_file.expected_stderr)
+    assert (stdout, stderr) == (testcase_file.expected_stdout, testcase_file.expected_stderr)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Windows paths are separated by a backslash but the tests assume a forward slash.

Fixes #13 